### PR TITLE
Add muli-bot support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
   goimports:
     local-prefixes: github.com/timkley/mattermost-plugin-bot-webhook
   govet:
-    check-shadowing: true
+    shadow: true
     enable-all: true
     disable:
       - fieldalignment

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "name": "Bot Webhook",
   "description": "This plugin allows you to send a webhook when a bot receives a message.",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "min_server_version": "6.2.1",
   "server": {
     "executables": {
@@ -14,28 +14,28 @@
       "windows-amd64": "server/dist/plugin-windows-amd64.exe"
     }
   },
-  "settings_schema": {
+    "settings_schema": {
     "settings": [
       {
         "key": "BotUserID",
-        "display_name": "Bot User ID",
-        "type": "text",
-        "help_text": "The user ID of the bot to listen for messages.",
-        "placeholder": "Enter the bot user ID",
+        "display_name": "Bot User IDs",
+        "type": "longtext",
+        "help_text": "The user ID of the bot to listen for messages. One on each line",
+        "placeholder": "Enter the bot user ID on each line",
         "default": ""
       },
       {
         "key": "WebhookURL",
-        "display_name": "Webhook URL",
-        "type": "text",
-        "help_text": "The URL to send the HTTP request to when the bot receives a message.",
-        "placeholder": "Enter the webhook URL",
+        "display_name": "Webhook URLs",
+        "type": "longtext",
+        "help_text": "The URL to send the HTTP request to when the bot receives a message. One on each line",
+        "placeholder": "Enter the webhook URL on each line",
         "default": ""
       },
       {
         "key": "BearerToken",
         "display_name": "Bearer Token",
-        "type": "text",
+        "type": "longtext",
         "help_text": "The bearer token to use for the HTTP request.",
         "placeholder": "Enter the Bearer token",
         "default": ""

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"bytes"
 	"encoding/json"
 	"net/http"
@@ -28,7 +29,7 @@ type BotWebhookPlugin struct {
 	botConfigMap  map[string]BotConfig
 }
 
-func parseBotConfig(botUserIDsStr, webhookURLsStr, bearerTokensStr string) map[string]BotConfig {
+func (p *BotWebhookPlugin) ParseBotConfig(botUserIDsStr, webhookURLsStr, bearerTokensStr string) map[string]BotConfig {
 	botUserIDs := strings.Split(botUserIDsStr, "\n")
 	webhookURLs := strings.Split(webhookURLsStr, "\n")
 	bearerTokens := strings.Split(bearerTokensStr, "\n")
@@ -74,7 +75,12 @@ func (p *BotWebhookPlugin) OnConfigurationChange() error {
 		return err
 	}
 	p.configuration = &configuration
-	p.botConfigMap = parseBotConfig(configuration.BotUserID, configuration.WebhookURL, configuration.BearerToken)
+	p.botConfigMap, err = p.ParseBotConfig(configuration.BotUserID, configuration.WebhookURL, configuration.BearerToken)
+	if err != nil {
+		p.API.LogError(err)
+		return err
+	}
+	
 	return nil
 }
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -65,7 +65,7 @@ func (p *BotWebhookPlugin) ParseBotConfig(botUserIDsStr, webhookURLsStr, bearerT
 		botConfigMap[botID] = botConfig
 	}
 
-	return botConfigMap
+	return botConfigMap, nil
 }
 
 func (p *BotWebhookPlugin) OnConfigurationChange() error {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -29,7 +29,7 @@ type BotWebhookPlugin struct {
 }
 
 func parseBotConfig(botUserIDsStr, webhookURLsStr, bearerTokensStr string) map[string]BotConfig {
-	botUserIDs := strings.Split(boMessageHasBeenPostedtUserIDsStr, "\n")
+	botUserIDs := strings.Split(botUserIDsStr, "\n")
 	webhookURLs := strings.Split(webhookURLsStr, "\n")
 	bearerTokens := strings.Split(bearerTokensStr, "\n")
 


### PR DESCRIPTION
Excellent plugin, thank you for you job. 
Add support multibot (in my case) for testing purposes: production vs staging. In other hands maybe in some cases it will be helpful when mm installation has many bots with different deployment (company with many developer's commands each has it's own bot).
